### PR TITLE
Change Lambda to Node 10

### DIFF
--- a/lambda/customresource.js
+++ b/lambda/customresource.js
@@ -29,8 +29,9 @@
  */
 
 var AWS = require("aws-sdk");
-var https = require("https");
-var url = require("url");
+//MJS 2020-01-24 comment out unused imports
+//var https = require("https");
+//var url = require("url");
 var s3 = new AWS.S3();
 var apiGateway = new AWS.APIGateway();
 var axios = require('axios');

--- a/package.json
+++ b/package.json
@@ -11,8 +11,11 @@
   "license": "Apache License",
   "dependencies": {
     "@anttiviljami/serverless-stack-output": "^0.3.1",
-    "serverless-parameters": "0.0.7",
     "axios": "0.18.0",
-    "debug": "4.1.1"
+    "debug": "4.1.1",
+    "uuid": "^3.4.0"
+  },
+  "devDependencies": {
+    "serverless-parameters": "^0.1.0"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,10 +7,8 @@ provider:
   region: ap-southeast-2  
   endpointType: REGIONAL
   runtime: nodejs10.x
-  # stage: dev
-  stage: prod
-  # profile: transcribe
-  profile: default
+  stage: dev
+  profile: transcribe
   logRetentionInDays: 7
 
 package:

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,15 +1,16 @@
 service: aws-captions
 
 plugins:
-  - 'serverless-parameters'
-
+  - serverless-parameters
 provider:
   name: aws
   region: ap-southeast-2  
   endpointType: REGIONAL
-  runtime: nodejs8.10
-  stage: dev
-  profile: transcribe
+  runtime: nodejs10.x
+  # stage: dev
+  stage: prod
+  # profile: transcribe
+  profile: default
   logRetentionInDays: 7
 
 package:
@@ -71,6 +72,7 @@ functions:
         - '**'
       include:
         - 'lambda/extractaudio.js'
+        - 'node_modules/uuid/**'
     memorySize: 128
     timeout: 15
 
@@ -94,8 +96,8 @@ functions:
       REGION: !Ref AWS::Region
       VOCABULARY_NAME: !Join [ '', [ '${self:custom.stage}-${self:service}-', !Ref TranscribeLanguage ] ]
       TRANSCRIBE_LANGUAGE: !Ref TranscribeLanguage
-    layers:
-      - !Ref LambdaLayer
+    # layers:
+    #   - !Ref LambdaLayer
     package:
       exclude:
         - '**'
@@ -254,8 +256,8 @@ functions:
       VIDEO_BUCKET: !Join ['', [ '${self:custom.stage}-${self:service}-video-', !Ref AWS::Region, '-', !Ref AWS::AccountId ] ]
       AUDIO_BUCKET: !Join ['', [ '${self:custom.stage}-${self:service}-audio-', !Ref AWS::Region, '-', !Ref AWS::AccountId ] ]
       TRANSCRIBE_BUCKET: !Ref S3BucketTranscribe
-    layers:
-      - !Ref LambdaLayer     
+    # layers:
+    #   - !Ref LambdaLayer     
     package:
       exclude:
         - '**'
@@ -282,8 +284,8 @@ functions:
       AUDIO_BUCKET: !Join ['', [ '${self:custom.stage}-${self:service}-audio-', !Ref AWS::Region, '-', !Ref AWS::AccountId ] ]
       TRANSCRIBE_BUCKET: !Ref S3BucketTranscribe
       EXTRACT_AUDIO_FUNCTION: '${self:custom.stage}-${self:service}-extractaudio'
-    layers:
-      - !Ref LambdaLayer     
+    # layers:
+    #   - !Ref LambdaLayer     
     package:
       exclude:
         - '**'
@@ -514,24 +516,24 @@ functions:
 resources:
   Resources:
 
-    LambdaLayer:
-      Type: 'AWS::Lambda::LayerVersion'
-      Properties:
-        CompatibleRuntimes: 
-          - nodejs8.10
-        Content: 
-          S3Bucket: aws-captions-deployment-ap-southeast-2
-          S3Key: layers/aws-captions-node-sdk-layer.zip
-        Description: 'Recent Node.js 8.10 AWS Node SDK'
-        LayerName: '${self:custom.stage}-aws-captions-node-sdk-layer'
-        LicenseInfo: Apache-2.0
+    # LambdaLayer:
+    #   Type: 'AWS::Lambda::LayerVersion'
+    #   Properties:
+    #     CompatibleRuntimes: 
+    #       - nodejs8.10
+    #     Content: 
+    #       S3Bucket: aws-captions-deployment-ap-southeast-2
+    #       S3Key: layers/aws-captions-node-sdk-layer.zip
+    #     Description: 'Recent Node.js 8.10 AWS Node SDK'
+    #     LayerName: '${self:custom.stage}-aws-captions-node-sdk-layer'
+    #     LicenseInfo: Apache-2.0
 
-    LambdaLayerPermission:
-      Type: 'AWS::Lambda::LayerVersionPermission'
-      Properties:
-        Action: lambda:GetLayerVersion
-        LayerVersionArn: !Ref LambdaLayer
-        Principal: !Ref AWS::AccountId
+    # LambdaLayerPermission:
+    #   Type: 'AWS::Lambda::LayerVersionPermission'
+    #   Properties:
+    #     Action: lambda:GetLayerVersion
+    #     LayerVersionArn: !Ref LambdaLayer
+    #     Principal: !Ref AWS::AccountId
 
     MyCustomResource: 
       Type: 'Custom::CustomResource'


### PR DESCRIPTION
*Issue #, if available: #17 

*Description of changes:
I have updated the Serverless template to support Node 10 deployments and will mean that people can continue to use this great solution.
I have removed the Lambda layer as this wasn't doing anything that I could see as the SDK is shipped with Node 10 runtime.
I have run an end to end test with this solution in my environment, initially the layer was causing issues as only working with Node 8, so I removed this.
The second issue was with the `ExtractAudio` Lambda which needs `uuid` and was not included in the project or Serverless confg, so I have updated this and this allowed me to deploy and run everything successfully.

As I said, I have been through all the Lambda functions (all 20 of them) to confirm the application is working fine. The only one that fails is the `Bootstrap` function as I don't have access to the external S3 bucket.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
