### PR TITLE
In some conditions caption endTime seems wrong.

### DIFF
--- a/lambda/createcaptions.js
+++ b/lambda/createcaptions.js
@@ -127,6 +127,8 @@ function computeCaptions(tweaks, transcribeResponse)
         }
     }
 
+    console.log('[INFO] logged all transcribe response items: ' + transcribeResponse.results.items);
+
     for (var i in transcribeResponse.results.items) {
 
         var item = transcribeResponse.results.items[i];

--- a/lambda/createcaptions.js
+++ b/lambda/createcaptions.js
@@ -127,8 +127,6 @@ function computeCaptions(tweaks, transcribeResponse)
         }
     }
 
-    console.log('[INFO] logged all transcribe response items: ' + transcribeResponse.results.items);
-
     for (var i in transcribeResponse.results.items) {
 
         var item = transcribeResponse.results.items[i];
@@ -167,7 +165,7 @@ function computeCaptions(tweaks, transcribeResponse)
              */
             if ((caption.caption.length > 0) && ((endTime + maxSilence) < startTime))
             {
-                caption.end = startTime;
+                caption.end = endTime;
                 captions.push(caption);
 
                 caption = {


### PR DESCRIPTION
*Issue #, if available:* In some conditions caption endTime seems wrong.

*Description of changes:* I have changed the caption.end value. It has to be `endTime`. When you use `startTime` then you close the caption endTime with current item's `startTime`. It seems wrong so we should use the previous item's `endTime`. 
You can also check ss. Before fixing, speaking completed in two seconds but the caption was still displayed.

Before fixing:
![image](https://user-images.githubusercontent.com/7747280/90650005-00f60c80-e244-11ea-8b63-cc22471b0d0f.png)

After fixing:
![image](https://user-images.githubusercontent.com/7747280/90650073-153a0980-e244-11ea-803a-375193dfbe21.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
